### PR TITLE
Graph: federated exclusion, kind-as-shape encoding, cross-kind edges

### DIFF
--- a/scripts/lib/corpus.mjs
+++ b/scripts/lib/corpus.mjs
@@ -181,21 +181,33 @@ export function buildCorpus() {
   }
   for (const soul of souls) soul.computed.backlinks.sort();
 
-  const nodes = souls.map((s) => ({
-    id: s.slug,
-    title: s.title,
-    category: s.metadata.category,
-    kind: s.metadata.kind,
-    difficulty: s.metadata.difficulty || null,
-    status: s.metadata.status,
-    verified: s.computed.verified,
-    federated: s.computed.federated,
-    tags: s.metadata.tags,
-    wordCount: s.computed.wordCount,
-    degree: 0,
-  }));
+  // The knowledge graph is the AUTHORED corpus only. Federated (externally
+  // mirrored) SOULs are browsable on their own pages but kept out of the graph:
+  // they rarely carry typed edges (so they'd float as orphans) and could number
+  // in the thousands, swamping a map that's meant to show the work we stand
+  // behind. Edges between authored SOULs of different kinds are preserved — those
+  // cross-kind links are exactly the connective tissue "beyond occupations" adds.
+  const inGraph = (slug) => {
+    const s = bySlug.get(slug);
+    return Boolean(s && !s.computed.federated);
+  };
+  const graphEdges = edges.filter((e) => inGraph(e.source) && inGraph(e.target));
+  const nodes = souls
+    .filter((s) => !s.computed.federated)
+    .map((s) => ({
+      id: s.slug,
+      title: s.title,
+      category: s.metadata.category,
+      kind: s.metadata.kind,
+      difficulty: s.metadata.difficulty || null,
+      status: s.metadata.status,
+      verified: s.computed.verified,
+      tags: s.metadata.tags,
+      wordCount: s.computed.wordCount,
+      degree: 0,
+    }));
   const degreeBySlug = new Map(nodes.map((n) => [n.id, 0]));
-  for (const e of edges) {
+  for (const e of graphEdges) {
     degreeBySlug.set(e.source, (degreeBySlug.get(e.source) || 0) + 1);
     degreeBySlug.set(e.target, (degreeBySlug.get(e.target) || 0) + 1);
   }
@@ -204,7 +216,7 @@ export function buildCorpus() {
   return {
     souls,
     bySlug,
-    graph: { nodes, edges },
+    graph: { nodes, edges: graphEdges },
     danglers,
   };
 }

--- a/scripts/lib/stats.mjs
+++ b/scripts/lib/stats.mjs
@@ -128,26 +128,31 @@ export function computeStats(corpus, gitBySlug = {}) {
     for (const c of contributors) contributorCounts[c] = (contributorCounts[c] || 0) + 1;
 
     totalWords += s.computed.wordCount;
-    if (s.computed.completeness < 1) {
-      incomplete.push({ slug: s.slug, title: s.title, completeness: s.computed.completeness });
-    }
-    if (!m.summary || !m.difficulty || (m.tags || []).length === 0) {
-      missingMetadata.push({
-        slug: s.slug,
-        title: s.title,
-        missing: [
-          !m.summary && 'summary',
-          !m.difficulty && 'difficulty',
-          (m.tags || []).length === 0 && 'tags',
-        ].filter(Boolean),
-      });
-    }
-    const reviewed = m.last_reviewed || m.updated;
-    if (reviewed && now - Date.parse(reviewed) > 1000 * 60 * 60 * 24 * 365) {
-      stalePages.push({ slug: s.slug, title: s.title, last: reviewed });
-    }
-    if ((adj.get(s.slug) || new Set()).size === 0) {
-      orphanPages.push({ slug: s.slug, title: s.title });
+    // Quality signals describe the authored corpus. Federated mirrors aren't ours
+    // to "complete" or "review", and they're not in the graph, so skip them here —
+    // otherwise every mirror would show up as incomplete debt and a graph orphan.
+    if (!s.computed.federated) {
+      if (s.computed.completeness < 1) {
+        incomplete.push({ slug: s.slug, title: s.title, completeness: s.computed.completeness });
+      }
+      if (!m.summary || !m.difficulty || (m.tags || []).length === 0) {
+        missingMetadata.push({
+          slug: s.slug,
+          title: s.title,
+          missing: [
+            !m.summary && 'summary',
+            !m.difficulty && 'difficulty',
+            (m.tags || []).length === 0 && 'tags',
+          ].filter(Boolean),
+        });
+      }
+      const reviewed = m.last_reviewed || m.updated;
+      if (reviewed && now - Date.parse(reviewed) > 1000 * 60 * 60 * 24 * 365) {
+        stalePages.push({ slug: s.slug, title: s.title, last: reviewed });
+      }
+      if ((adj.get(s.slug) || new Set()).size === 0) {
+        orphanPages.push({ slug: s.slug, title: s.title });
+      }
     }
   }
 

--- a/src/components/GraphView.astro
+++ b/src/components/GraphView.astro
@@ -53,6 +53,13 @@ const base = import.meta.env.BASE_URL;
             <option value={name}>{name}</option>
           ))}
         </select>
+        <select
+          class="rounded-md border bg-transparent px-2 py-1.5 text-sm outline-none"
+          style="border-color:var(--border); color:var(--ink); display:none"
+          data-graph-kind-filter
+        >
+          <option value="">All kinds</option>
+        </select>
         <span class="text-xs" style="color:var(--ink-faint)" data-graph-count />
         <span class="ml-auto text-xs" style="color:var(--ink-faint)">
           drag · scroll to zoom · click to open
@@ -106,6 +113,29 @@ const base = import.meta.env.BASE_URL;
     'Life Roles': '#fb7185',
   };
   const color = (c: string) => CATEGORY_COLORS[c] ?? '#94a3b8';
+
+  // Kind is encoded by node SHAPE (colour stays = category). Occupations are
+  // circles (the overwhelming majority); other ways of thinking get a distinct
+  // glyph so they read at a glance.
+  const KIND_SYMBOLS: Record<string, any> = {
+    occupation: d3.symbolCircle,
+    discipline: d3.symbolDiamond,
+    role: d3.symbolSquare,
+    identity: d3.symbolTriangle,
+    community: d3.symbolWye,
+    historical: d3.symbolCross,
+    'agent-persona': d3.symbolStar,
+  };
+  const KIND_LABELS: Record<string, string> = {
+    occupation: 'Occupation',
+    discipline: 'Discipline',
+    role: 'Role',
+    identity: 'Identity',
+    community: 'Community',
+    historical: 'Historical',
+    'agent-persona': 'Agent persona',
+  };
+  const symbolFor = (kind: string) => KIND_SYMBOLS[kind] ?? d3.symbolCircle;
 
   async function initGraph(wrap: Element) {
     const canvas = wrap.querySelector('[data-graph-canvas]') as HTMLElement;
@@ -176,8 +206,14 @@ const base = import.meta.env.BASE_URL;
     const node = root.append('g').selectAll('g').data(nodes).join('g').style('cursor', 'pointer');
 
     node
-      .append('circle')
-      .attr('r', (d: any) => sizeScale(d.degree))
+      .append('path')
+      .attr('d', (d: any) =>
+        d3
+          .symbol()
+          .type(symbolFor(d.kind))
+          // size is area; match the equivalent circle radius so shapes feel even
+          .size(Math.PI * Math.pow(sizeScale(d.degree), 2))(),
+      )
       .attr('fill', (d: any) => color(d.category))
       .attr('stroke', (d: any) => (d.id === focus ? 'var(--ink)' : 'var(--surface)'))
       .attr('stroke-width', (d: any) => (d.id === focus ? 2.5 : 1));
@@ -213,7 +249,9 @@ const base = import.meta.env.BASE_URL;
       .on('mouseenter', (ev: any, d: any) => {
         highlight(d.id);
         tip.style.display = 'block';
-        tip.textContent = `${d.title} — ${d.category} · ${d.degree} links`;
+        const kindBit =
+          d.kind && d.kind !== 'occupation' ? `${KIND_LABELS[d.kind] ?? d.kind} · ` : '';
+        tip.textContent = `${d.title} — ${kindBit}${d.category} · ${d.degree} links`;
       })
       .on('mouseleave', () => {
         highlight(focus);
@@ -306,6 +344,31 @@ const base = import.meta.env.BASE_URL;
           !c || d.source.category === c || d.target.category === c ? 0.6 : 0.03,
         );
       });
+    }
+
+    // Kind filter: populated from the kinds actually present in this graph, so
+    // it only appears once the Atlas covers more than occupations.
+    const kindFilter = wrap.querySelector('[data-graph-kind-filter]') as HTMLSelectElement | null;
+    if (kindFilter) {
+      const present = [...new Set(nodes.map((n: any) => n.kind || 'occupation'))];
+      if (present.length > 1) {
+        for (const k of present.sort()) {
+          const opt = document.createElement('option');
+          opt.value = k;
+          opt.textContent = KIND_LABELS[k] ?? k;
+          kindFilter.appendChild(opt);
+        }
+        kindFilter.style.display = '';
+        kindFilter.addEventListener('change', () => {
+          const k = kindFilter.value;
+          node.style('opacity', (d: any) => (!k || (d.kind || 'occupation') === k ? 1 : 0.08));
+          link.style('opacity', (d: any) =>
+            !k || (d.source.kind || 'occupation') === k || (d.target.kind || 'occupation') === k
+              ? 0.6
+              : 0.03,
+          );
+        });
+      }
     }
   }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -121,7 +121,6 @@ export interface GraphData {
     difficulty: string | null;
     status: string;
     verified: boolean;
-    federated: boolean;
     tags: string[];
     wordCount: number;
     degree: number;

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -1,12 +1,45 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import GraphView from '../components/GraphView.astro';
-import { graph, stats, CATEGORY_COLORS } from '../lib/data';
+import { graph, stats, CATEGORY_COLORS, kindLabel } from '../lib/data';
 import { url } from '../lib/site';
+import {
+  symbol,
+  symbolCircle,
+  symbolDiamond,
+  symbolSquare,
+  symbolTriangle,
+  symbolWye,
+  symbolCross,
+  symbolStar,
+} from 'd3';
 
 const legend = Object.entries(CATEGORY_COLORS).filter(([name]) =>
   graph.nodes.some((n) => n.category === name),
 );
+
+// Kind is encoded as node shape; build a matching legend from the d3 symbols,
+// for the kinds actually present in the graph. Only shown once we're past
+// occupation-only (i.e. more than one kind), so today it renders nothing.
+const KIND_SYMBOLS: Record<string, any> = {
+  occupation: symbolCircle,
+  discipline: symbolDiamond,
+  role: symbolSquare,
+  identity: symbolTriangle,
+  community: symbolWye,
+  historical: symbolCross,
+  'agent-persona': symbolStar,
+};
+const kindsInGraph = [...new Set(graph.nodes.map((n: any) => n.kind || 'occupation'))].sort();
+const kindLegend =
+  kindsInGraph.length > 1
+    ? kindsInGraph.map((k) => ({
+        label: kindLabel(k),
+        path: symbol()
+          .type(KIND_SYMBOLS[k] ?? symbolCircle)
+          .size(70)(),
+      }))
+    : [];
 ---
 
 <Layout
@@ -41,6 +74,24 @@ const legend = Object.entries(CATEGORY_COLORS).filter(([name]) =>
         ))
       }
     </div>
+
+    {
+      kindLegend.length > 0 && (
+        <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <span class="text-xs" style="color:var(--ink-faint)">
+            Shape = kind:
+          </span>
+          {kindLegend.map((k) => (
+            <span class="inline-flex items-center gap-1.5 text-xs" style="color:var(--ink-soft)">
+              <svg width="14" height="14" viewBox="-8 -8 16 16" aria-hidden="true">
+                <path d={k.path} fill="var(--ink-soft)" />
+              </svg>
+              {k.label}
+            </span>
+          ))}
+        </div>
+      )
+    }
 
     <div class="mt-8 grid gap-4 sm:grid-cols-3">
       <div class="card p-4">


### PR DESCRIPTION
## Why

Phase 2 added the `kind` axis and federation-readiness, but the **knowledge graph** still treated every node identically and would have included federated mirrors. Before any non-occupation or federated content lands (Phase 3), this makes the graph ready so the first batch makes it *richer*, not messier.

## Changes

**Federated exclusion ([corpus.mjs](scripts/lib/corpus.mjs))**
The graph is now built from the **authored** corpus only. Federated (externally-mirrored) SOULs are dropped from nodes, and any edge touching them is removed. Rationale: mirrors rarely carry typed edges (they'd float as orphans) and could number in the thousands (souls.directory's "Art" alone is ~4,600) — that would swamp a map meant to show the work we stand behind. Consistent with the Phase-2 stats exclusion.

**Cross-kind edges preserved**
Edges between authored SOULs of *different* kinds (e.g. `philosopher` → `stoic`) are kept — that connective tissue is exactly what "beyond occupations" adds to the graph.

**Quality stats scoped to authored ([stats.mjs](scripts/lib/stats.mjs))**
Federated entries no longer count toward incomplete / missing-metadata / stale / orphan signals, so mirrors don't show up as our quality debt. `byKind`/`byCategory` still include them for the breakdowns.

**Kind encoded as node shape ([GraphView.astro](src/components/GraphView.astro))**
Colour stays = category; **shape** now encodes kind — circle (occupation), diamond (discipline), square (role), triangle (identity), wye (community), cross (historical), star (agent-persona). The tooltip names the kind for non-occupations, and a **kind filter** appears only once the graph holds more than one kind (populated from the kinds actually present).

**Legend ([graph.astro](src/pages/graph.astro))**
A "Shape = kind" legend using the exact d3 symbols (server-rendered), shown only when >1 kind is present — so today it renders nothing.

## Testing

- Occupation-only output **unchanged**: 383 graph nodes, `byKind: {occupation: 383}`.
- Smoke-tested with temporary `discipline` + federated `agent-persona` entries:
  - graph = 384 nodes (discipline included, **federated excluded**)
  - **cross-kind authored edge preserved** (`discipline → physician`); **federated edge dropped**
  - federated **not** counted as orphan/incomplete
  - shapes (diamond + circle), `Shape = kind` legend, and kind filter all render
  - then removed — committed corpus unchanged.
- `npm run validate` (0 errors), `npm run build` (green), `format:check` + `lint:md` clean.

## Deferred
- A "show federated" graph toggle (mirrors are mostly orphans; excluding is the right default — revisit if there's demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)