### PR TITLE
Fix: graph filters hide non-matching nodes instead of dimming

### DIFF
--- a/src/components/GraphView.astro
+++ b/src/components/GraphView.astro
@@ -336,19 +336,31 @@ const base = import.meta.env.BASE_URL;
         }
       });
     }
-    if (filter) {
-      filter.addEventListener('change', () => {
-        const c = filter.value;
-        node.style('opacity', (d: any) => (!c || d.category === c ? 1 : 0.08));
-        link.style('opacity', (d: any) =>
-          !c || d.source.category === c || d.target.category === c ? 0.6 : 0.03,
-        );
-      });
+    // Category + kind filters HIDE non-matching nodes (and any edge touching a
+    // hidden node), rather than just dimming them. Both selects apply together.
+    const kindFilter = wrap.querySelector('[data-graph-kind-filter]') as HTMLSelectElement | null;
+    const nodeShown = (d: any) => {
+      const c = filter ? filter.value : '';
+      const k = kindFilter ? kindFilter.value : '';
+      return (!c || d.category === c) && (!k || (d.kind || 'occupation') === k);
+    };
+    function applyFilters() {
+      node.style('display', (d: any) => (nodeShown(d) ? null : 'none'));
+      link.style('display', (d: any) =>
+        nodeShown(d.source) && nodeShown(d.target) ? null : 'none',
+      );
+      if (count) {
+        const active = (filter && filter.value) || (kindFilter && kindFilter.value);
+        const vis = nodes.filter(nodeShown).length;
+        count.textContent = active
+          ? `${vis} of ${nodes.length} nodes`
+          : `${nodes.length} nodes · ${links.length} edges`;
+      }
     }
+    if (filter) filter.addEventListener('change', applyFilters);
 
     // Kind filter: populated from the kinds actually present in this graph, so
     // it only appears once the Atlas covers more than occupations.
-    const kindFilter = wrap.querySelector('[data-graph-kind-filter]') as HTMLSelectElement | null;
     if (kindFilter) {
       const present = [...new Set(nodes.map((n: any) => n.kind || 'occupation'))];
       if (present.length > 1) {
@@ -359,15 +371,7 @@ const base = import.meta.env.BASE_URL;
           kindFilter.appendChild(opt);
         }
         kindFilter.style.display = '';
-        kindFilter.addEventListener('change', () => {
-          const k = kindFilter.value;
-          node.style('opacity', (d: any) => (!k || (d.kind || 'occupation') === k ? 1 : 0.08));
-          link.style('opacity', (d: any) =>
-            !k || (d.source.kind || 'occupation') === k || (d.target.kind || 'occupation') === k
-              ? 0.6
-              : 0.03,
-          );
-        });
+        kindFilter.addEventListener('change', applyFilters);
       }
     }
   }


### PR DESCRIPTION
## Problem

Selecting a category (or kind) in the knowledge graph only **dimmed** non-matching nodes to opacity `0.08` — they stayed visible, so it didn't read as a filter (reported with "Law" selected but the whole graph still showing).

## Fix

[GraphView.astro](src/components/GraphView.astro): the category and kind filters now **hide** (`display:none`) non-matching nodes and any edge touching a hidden node, rather than dimming. The two selects apply **together** via a single `applyFilters()`, and the count shows `N of M nodes` while a filter is active (resets to the full total when cleared).

Hover-highlight and search keep their existing dim behavior (different intent — emphasis, not filtering).

## Testing
- `npm run build` → green. Logic verified: `nodeShown(d)` gates node display; edges show only when both endpoints are shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)