### PR TITLE
Graph dark-theme + multi-kind filter, constellation logo, real SOUL c…

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
   <rect width="24" height="24" rx="5" fill="#1f4fda" />
-  <circle cx="12" cy="12" r="6.4" stroke="#fff" stroke-width="1.5" />
-  <circle cx="12" cy="12" r="2.3" fill="#fff" />
-  <path d="M12 4.2v2M12 17.8v2M4.2 12h2M17.8 12h2" stroke="#fff" stroke-width="1.5" stroke-linecap="round" />
+  <g stroke="#fff" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.55">
+    <path d="M6.5 7L14 4.5L19.5 9.5L16.5 17L8 18M19.5 9.5L12.5 11.5L8 18" />
+  </g>
+  <g fill="#fff">
+    <circle cx="6.5" cy="7" r="2.7" />
+    <circle cx="14" cy="4.5" r="1.5" />
+    <circle cx="19.5" cy="9.5" r="2.1" />
+    <circle cx="16.5" cy="17" r="1.8" />
+    <circle cx="8" cy="18" r="1.5" />
+    <circle cx="12.5" cy="11.5" r="1.2" />
+  </g>
+  <g fill="#fff" fill-opacity="0.45">
+    <circle cx="20.5" cy="18.5" r="0.85" />
+    <circle cx="4" cy="13.5" r="0.85" />
+  </g>
 </svg>

--- a/src/components/GraphView.astro
+++ b/src/components/GraphView.astro
@@ -53,13 +53,12 @@ const base = import.meta.env.BASE_URL;
             <option value={name}>{name}</option>
           ))}
         </select>
-        <select
-          class="rounded-md border bg-transparent px-2 py-1.5 text-sm outline-none"
-          style="border-color:var(--border); color:var(--ink); display:none"
-          data-graph-kind-filter
-        >
-          <option value="">All kinds</option>
-        </select>
+        <div
+          class="hidden flex-wrap items-center gap-1"
+          data-graph-kind-chips
+          role="group"
+          aria-label="Filter by kind (toggle any number)"
+        />
         <span class="text-xs" style="color:var(--ink-faint)" data-graph-count />
         <span class="ml-auto text-xs" style="color:var(--ink-faint)">
           drag · scroll to zoom · click to open
@@ -180,7 +179,9 @@ const base = import.meta.env.BASE_URL;
     svg.call(zoom as any);
 
     const linkStroke: Record<string, string> = {
-      related: 'var(--border)',
+      // --border is nearly invisible in dark mode; most cross-kind edges are
+      // "related", so stroke them in a muted-but-visible ink instead.
+      related: 'var(--ink-faint)',
       specialization: '#8b5cf6',
       prerequisite: '#f59e0b',
       adjacent: '#06b6d4',
@@ -336,13 +337,15 @@ const base = import.meta.env.BASE_URL;
         }
       });
     }
-    // Category + kind filters HIDE non-matching nodes (and any edge touching a
-    // hidden node), rather than just dimming them. Both selects apply together.
-    const kindFilter = wrap.querySelector('[data-graph-kind-filter]') as HTMLSelectElement | null;
+    // Category (single) + kind (multi) filters HIDE non-matching nodes and any
+    // edge touching a hidden node, rather than dimming. Empty kind set = all kinds.
+    const selectedKinds = new Set<string>();
     const nodeShown = (d: any) => {
       const c = filter ? filter.value : '';
-      const k = kindFilter ? kindFilter.value : '';
-      return (!c || d.category === c) && (!k || (d.kind || 'occupation') === k);
+      return (
+        (!c || d.category === c) &&
+        (selectedKinds.size === 0 || selectedKinds.has(d.kind || 'occupation'))
+      );
     };
     function applyFilters() {
       node.style('display', (d: any) => (nodeShown(d) ? null : 'none'));
@@ -350,7 +353,7 @@ const base = import.meta.env.BASE_URL;
         nodeShown(d.source) && nodeShown(d.target) ? null : 'none',
       );
       if (count) {
-        const active = (filter && filter.value) || (kindFilter && kindFilter.value);
+        const active = (filter && filter.value) || selectedKinds.size > 0;
         const vis = nodes.filter(nodeShown).length;
         count.textContent = active
           ? `${vis} of ${nodes.length} nodes`
@@ -359,19 +362,37 @@ const base = import.meta.env.BASE_URL;
     }
     if (filter) filter.addEventListener('change', applyFilters);
 
-    // Kind filter: populated from the kinds actually present in this graph, so
-    // it only appears once the Atlas covers more than occupations.
-    if (kindFilter) {
-      const present = [...new Set(nodes.map((n: any) => n.kind || 'occupation'))];
+    // Kind chips: one toggle per kind present in this graph (so they only appear
+    // once the Atlas covers more than occupations). Toggle any number on/off.
+    const kindChips = wrap.querySelector('[data-graph-kind-chips]') as HTMLElement | null;
+    if (kindChips) {
+      const present = [...new Set(nodes.map((n: any) => n.kind || 'occupation'))].sort();
       if (present.length > 1) {
-        for (const k of present.sort()) {
-          const opt = document.createElement('option');
-          opt.value = k;
-          opt.textContent = KIND_LABELS[k] ?? k;
-          kindFilter.appendChild(opt);
+        const paint = (b: HTMLButtonElement, on: boolean) => {
+          b.style.background = on ? 'var(--accent-soft)' : 'transparent';
+          b.style.color = on ? 'var(--accent)' : 'var(--ink-soft)';
+          b.style.borderColor = on ? 'var(--accent)' : 'var(--border)';
+        };
+        for (const k of present) {
+          const b = document.createElement('button');
+          b.type = 'button';
+          b.className = 'rounded-md border px-2 py-1 text-xs';
+          b.dataset.kind = k;
+          b.setAttribute('aria-pressed', 'false');
+          b.textContent = KIND_LABELS[k] ?? k;
+          paint(b, false);
+          b.addEventListener('click', () => {
+            const on = b.getAttribute('aria-pressed') !== 'true';
+            b.setAttribute('aria-pressed', String(on));
+            if (on) selectedKinds.add(k);
+            else selectedKinds.delete(k);
+            paint(b, on);
+            applyFilters();
+          });
+          kindChips.appendChild(b);
         }
-        kindFilter.style.display = '';
-        kindFilter.addEventListener('change', applyFilters);
+        kindChips.classList.remove('hidden');
+        kindChips.classList.add('flex');
       }
     }
   }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,13 +25,27 @@ const isActive = (href: string) =>
       style="color:var(--ink)"
     >
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <circle cx="12" cy="12" r="9" stroke="var(--accent)" stroke-width="1.6"></circle>
-        <circle cx="12" cy="12" r="3.2" fill="var(--accent)"></circle>
-        <path
-          d="M12 3v3M12 18v3M3 12h3M18 12h3"
+        <g
           stroke="var(--accent)"
-          stroke-width="1.6"
-          stroke-linecap="round"></path>
+          stroke-width="1.1"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-opacity="0.45"
+        >
+          <path d="M6.5 7L14 4.5L19.5 9.5L16.5 17L8 18M19.5 9.5L12.5 11.5L8 18"></path>
+        </g>
+        <g fill="var(--accent)">
+          <circle cx="6.5" cy="7" r="2.7"></circle>
+          <circle cx="14" cy="4.5" r="1.5"></circle>
+          <circle cx="19.5" cy="9.5" r="2.1"></circle>
+          <circle cx="16.5" cy="17" r="1.8"></circle>
+          <circle cx="8" cy="18" r="1.5"></circle>
+          <circle cx="12.5" cy="11.5" r="1.2"></circle>
+        </g>
+        <g fill="var(--accent)" fill-opacity="0.4">
+          <circle cx="20.5" cy="18.5" r="0.85"></circle>
+          <circle cx="4" cy="13.5" r="0.85"></circle>
+        </g>
       </svg>
       <span>SOUL <span style="color:var(--ink-faint)">Atlas</span></span>
     </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const jsonLd = {
     <div class="mx-auto max-w-5xl px-4 py-20 text-center">
       <div class="mb-5 inline-flex items-center gap-2 chip">
         <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:var(--accent)"></span>
-        Open · MIT License · {Math.floor(souls.length / 100) * 100}+ SOULs and growing
+        Open · MIT License · {souls.length.toLocaleString('en-US')} SOULs and growing
       </div>
       <h1
         class="mx-auto max-w-3xl text-4xl font-bold leading-[1.1] tracking-tight sm:text-6xl"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,6 +65,18 @@ a {
   color: var(--accent);
 }
 
+/* Native <select> popups are OS-rendered and otherwise show near-white option
+   text on a white background in dark mode. Give the options an explicit dark
+   surface so they stay legible in both themes. */
+select {
+  background-color: var(--surface);
+  color: var(--ink);
+}
+select option {
+  background-color: var(--surface);
+  color: var(--ink);
+}
+
 /* Focus visibility for keyboard users (WCAG 2.4.7). */
 :focus-visible {
   outline: 2px solid var(--accent);


### PR DESCRIPTION
…ount

- Graph: native <select> option popups were near-white text on white in dark mode — give selects/options an explicit surface (global, so Explore benefits too). "related" edges were stroked in near-invisible --border; use --ink-faint so the cross-kind connections actually show.
- Graph: kind filter is now multi-select — a row of toggle chips (any number), replacing the single-choice dropdown; applies together with the category filter.
- Logo + favicon: replace the generic target/compass mark with an irregular constellation (varied star sizes, asymmetric links, faint background specks) — a nod to the knowledge graph and "a galaxy of connected minds."
- Home hero: show the actual SOUL count instead of a rounded "600+".

<!-- Thanks for contributing to SOUL Atlas! -->

## What does this PR do?

<!-- New SOUL? Improvement to an existing one? Platform change? Briefly describe. -->

## Type

- [ ] New SOUL
- [ ] Improvement / correction to an existing SOUL
- [ ] Platform (engine, website, schema, docs)

## Checklist

- [ ] `npm run validate` passes with **zero errors**
- [ ] `npm run check` passes (validate + lint + format)
- [ ] For content: every required section is substantive — no placeholders, no filler
- [ ] For content: reads like a practitioner wrote it; no [banned phrases](../STYLE_GUIDE.md#banned-phrases-ai-tells)
- [ ] For content: `metadata.yaml` complete; `slug` matches the directory; 4–6 typed `related` edges to real slugs
- [ ] One SOUL / one focused change per PR where practical

## Notes for reviewers

<!-- Anything you're unsure about, or specifically want feedback on. -->
